### PR TITLE
Fix multi argument indent when using noexpandtab; make it optional

### DIFF
--- a/after/indent/lua.vim
+++ b/after/indent/lua.vim
@@ -102,6 +102,7 @@ function s:IsMultiLineComment()
   return s:synname(v:lnum, 1) == 'luaComment'
 endfunction
 
+" Amount of indent the input string contains.
 function s:GetStringIndent(str)
   let indent = 0
   for i in range(len(a:str))
@@ -115,6 +116,20 @@ function s:GetStringIndent(str)
   endfor
   return indent
 endfunction
+
+" Amount of indent required to match input characters.
+function s:GetIndentForChars(str)
+  let indent = 0
+  for i in range(len(a:str))
+    if a:str[i] == "\t"
+      let indent += &shiftwidth
+    else
+      let indent += 1
+    endif
+  endfor
+  return indent
+endfunction
+
 
 function s:LinesParenBalanced(lines)
   let balance = 0
@@ -255,7 +270,7 @@ function! s:FindFirstUnbalancedParen(lines)
           if match(line, '\v^.+\(.*<function>' ) > -1
             return s:GetStringIndent(line) + &shiftwidth
           else
-            return i + 1
+            return s:GetIndentForChars(line[:i])
           endif
         endif
       endif

--- a/after/indent/lua.vim
+++ b/after/indent/lua.vim
@@ -19,6 +19,8 @@ if exists("g:lua_indent_version") && g:lua_indent_version == 2
 endif
 let g:lua_indent_version = 2
 
+let g:lua_indent_align_params = get(g:, 'lua_indent_align_params', 1)
+
 function s:IsLineBlank(line)
   return a:line =~# '\m\v^\s*$'
 endfunction
@@ -267,7 +269,7 @@ function! s:FindFirstUnbalancedParen(lines)
       elseif line[i] == '('
         let balance -= 1
         if balance < 0
-          if match(line, '\v^.+\(.*<function>' ) > -1
+          if !g:lua_indent_align_params || (match(line, '\v^.+\(.*<function>' ) > -1)
             return s:GetStringIndent(line) + &shiftwidth
           else
             return s:GetIndentForChars(line[:i])


### PR DESCRIPTION
Cleaned up version of suokko's fix from #2 to more closely match existing code style and naming.

We must \t as &shiftwidth instead of a single char. Can't use
GetStringIndent because it stops when it hits non whitespace and making
it support both cases is awkward.

With `noet sw=8 ts=8` old behaviour:

```lua
f = function(a,
	     b)
	print(a)
	g = function(a,
	      b)
	end
end

```
New behaviour fixes indent for g:

```lua
f = function(a,
	     b)
	print(a)
	g = function(a,
		     b)
	end
end
```

----

Also add  g:lua_indent_align_params. `let g:lua_indent_align_params = 0` for single indent for function params:

```lua
  f = function(a,
      b)
      print(a)
      g = function(a,
          b)
      end
  end
  g = function(a,
      b)
  end

  create(10,
      20,
      30,
      get(
          1,
          2),
      val())
```

Trying to evaluate indentation in this plugin vs tbastos/vim-lua, so I thought I'd contribute some changes I made along the way. In the end, tbastos's version seems like it'll better support chained function calls so that may be a deciding factor for me.