### PR TITLE
Unindent 'then' on a line by itself

### DIFF
--- a/test/indent.vader
+++ b/test/indent.vader
@@ -1,0 +1,30 @@
+Before:
+  setlocal expandtab shiftwidth=4 tabstop=4
+
+Given lua (long if statement):
+  if hasTaste()
+    and lovesTaste()
+    and gottaHaveIt()
+  then
+    eatIt()
+    if true then
+      print("ate")
+    end
+    if false then print("printed ate") end
+  end
+
+Do (reindent):
+  gg=G
+
+Expect lua (solitary 'then' unindented):
+  if hasTaste()
+      and lovesTaste()
+      and gottaHaveIt()
+  then
+      eatIt()
+      if true then
+          print("ate")
+      end
+      if false then print("printed ate") end
+  end
+


### PR DESCRIPTION
Unindent a solitary 'then' to separate the if conditions from the if body.

Example:
```lua
if true
    and false
then
    print()
end
```
Add vader test.